### PR TITLE
Replaced "deno build" with "deno task build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To deploy your `create-next-app` to Deno Deploy:
 1. Build your app
 
 ```bash
-deno build
+deno task build
 ```
 
 2. Deploy


### PR DESCRIPTION
Very tiny change: The command that builds the Next.js app should actually be `deno task build`.

Calling `deno build` triggers the following error:
```
error: unrecognized subcommand

tip: a similar subcommand exists: 'bundle'
```

Note: Tested with Deno v2.0.2 on Arch Linux.