### PR TITLE
fix: upgrade Next.js to 15.0.6 (CVE-2025-55182)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "react": "19.0.0-rc-69d4b800-20241021",
     "react-dom": "19.0.0-rc-69d4b800-20241021",
-    "next": "15.0.1"
+    "next": "15.0.6"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
This upgrade fixes CVE-2025-55182, a React Server Components RCE vulnerability.